### PR TITLE
[BR-27] fixed fetching for saved category bar chart

### DIFF
--- a/client/src/components/WeeklyChart.tsx
+++ b/client/src/components/WeeklyChart.tsx
@@ -39,9 +39,13 @@ const chartConfig = {
 
 interface WeeklyChartProps {
   weekly_summary_id: number | null;
+  isRecent?: boolean;
 }
 
-export function WeeklyChart({ weekly_summary_id }: WeeklyChartProps) {
+export function WeeklyChart({
+  weekly_summary_id,
+  isRecent = false,
+}: WeeklyChartProps) {
   const { data: user } = useQuery<User>({
     queryKey: ["user"],
     queryFn: getUser,
@@ -52,7 +56,7 @@ export function WeeklyChart({ weekly_summary_id }: WeeklyChartProps) {
     queryKey: ["weekchart", weekly_summary_id ?? undefined],
     queryFn: async () => {
       const response = await fetch(
-        `${import.meta.env.VITE_SERVER_URL}/charts/user/${user?.user_id}/weekly_summary/${weekly_summary_id}`
+        `${import.meta.env.VITE_SERVER_URL}/charts/user/${user?.user_id}/weekly_summary/${weekly_summary_id ?? 0}/?isRecent=${isRecent}`
       );
 
       if (!response.ok) {

--- a/client/src/routes/home/wrapup/WrapupInfoPage.tsx
+++ b/client/src/routes/home/wrapup/WrapupInfoPage.tsx
@@ -6,6 +6,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { WeeklyChart } from "@/components/WeeklyChart";
 import { BackendResponse } from "@/interfaces/BackendResponse";
 import getUser from "@/utils/getUser";
 import { User, WeeklySummary, Expense, Category } from "@/utils/types";
@@ -98,10 +99,17 @@ const WrapupInfoPage = () => {
       <div className="ml-5 mt-3 text-4xl font-bold">Week-End Review</div>
       <hr className="ml-6 mr-6 mt-3 border-t-2 border-slate-950" />
       <div className="ml-8 mt-3 flex gap-80">
-        <div>
-          <h4 className="text-lg font-medium">Summary of Expenses</h4>
-          <div className="h-[15rem] w-[30rem] bg-slate-700 text-white">
-            insert ang graph here
+        <div className="flex flex-col">
+          <div>
+            <h4 className="text-lg font-medium">Summary of Expenses</h4>
+            <div className="">
+              {wrapUpInfo?.weekly_summary_id && ( //checks if weekly_summary_id exists
+                <WeeklyChart
+                  weekly_summary_id={wrapUpInfo?.weekly_summary_id}
+                  isRecent={true}
+                />
+              )}
+            </div>
           </div>
           <div className="ml-2 mt-3">
             <h4 className="text-lg font-medium">

--- a/client/src/routes/home/wrapup/WrapupInfoPage.tsx
+++ b/client/src/routes/home/wrapup/WrapupInfoPage.tsx
@@ -6,6 +6,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@/components/ui/carousel";
+import { DrawerDemo } from "@/components/ui/DrawerDemo";
 import { WeeklyChart } from "@/components/WeeklyChart";
 import { BackendResponse } from "@/interfaces/BackendResponse";
 import getUser from "@/utils/getUser";
@@ -21,6 +22,8 @@ const WrapupInfoPage = () => {
 
   const [spentPercentage, setSpentPercentage] = useState<number>(0);
   const [savedPercentage, setSavePercentage] = useState<number>(0);
+
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const { data: wrapUpInfo, isLoading } = useQuery({
     enabled: !!user, // Only fetch wrapUpInfo if the user is available
@@ -198,6 +201,17 @@ const WrapupInfoPage = () => {
             )}
           </div>
         </div>
+      </div>
+
+      <button
+        className="bg-green absolute bottom-10 right-44 rounded px-4 py-2 text-white hover:bg-teal-700"
+        onClick={() => setIsDrawerOpen(true)}
+      >
+        Next
+      </button>
+
+      <div className="absolute bottom-6 left-6">
+        <DrawerDemo open={isDrawerOpen} setOpen={setIsDrawerOpen} />
       </div>
     </div>
   );

--- a/server/routes/charts.ts
+++ b/server/routes/charts.ts
@@ -90,24 +90,25 @@ chartRouter.get(
               JOIN
               "Weekly Summary" ws
                 ON sc.weekly_summary_id = ws.weekly_summary_id
-              ON
-                e.saved_category_id = sc.saved_category_id
               WHERE
                 sc.weekly_summary_id = $1
                 `,
             [weekly_summary_id]
           );
 
+          const date_start = new Date(rows[0].date_start).toDateString();
+          const date_end = new Date(rows[0].date_end).toDateString();
+
           console.log(rows);
-          console.log(rows[0].date_start);
-          console.log(rows[0].date_end);
+          console.log(date_start);
+          console.log(date_end);
 
           const arranged = groupExpensesByDay(rows);
           res.status(200).json({
             data: {
               arranged,
-              date_start: rows[0].date_start,
-              date_end: rows[0].date_end,
+              date_start: date_start,
+              date_end: date_end,
             },
           });
         }

--- a/server/routes/charts.ts
+++ b/server/routes/charts.ts
@@ -10,19 +10,21 @@ chartRouter.get(
   "/user/:user_id/weekly_summary/:weekly_summary_id",
   async (req: Request, res: Response) => {
     const { user_id, weekly_summary_id } = req.params;
-
+    const { isRecent } = req.query;
+    console.log(weekly_summary_id);
     try {
-      if (parseInt(weekly_summary_id) != 0) {
+      if (weekly_summary_id === "0") {
+        console.log("parse equal to 0");
         // SQL Query with user_id filter
         const query = `SELECT e.total, e.date
-      FROM
-        "Expense" e
-      LEFT JOIN
-        "Category" c
-        ON e.category_id = c.category_id
-      WHERE
-        c.user_id = $1
-      `;
+          FROM
+            "Expense" e
+          LEFT JOIN
+            "Category" c
+            ON e.category_id = c.category_id
+          WHERE
+            c.user_id = $1
+        `;
 
         // Pass user_id as a parameter to the query
         const { rows } = await pool.query<Expense>(query, [user_id]);
@@ -41,28 +43,74 @@ chartRouter.get(
           },
         });
       } else {
-        const { rows } = await pool.query(
-          `SELECT e.total, e.date, sc.date_start, sc.date_end FROM "Expense" e
+        if (isRecent === "true") {
+          const { rows } = await pool.query(
+            `SELECT e.total, e.date FROM "Expense" e
               LEFT JOIN
-                "Saved Categories" sc
+                "Category" c
+              ON e.category_id = c.category_id
+              WHERE c.user_id = $1
+            `,
+            [user_id]
+          );
+
+          const { rows: weeklySummaryRows } = await pool.query(
+            `SELECT date_start, date_end FROM "Weekly Summary"
+              WHERE user_id = $1
+              ORDER BY weekly_summary_id
+              DESC LIMIT 1`,
+            [user_id]
+          );
+
+          const date_start = new Date(
+            weeklySummaryRows[0].date_start
+          ).toDateString();
+          const date_end = new Date(
+            weeklySummaryRows[0].date_end
+          ).toDateString();
+
+          console.log(rows);
+          console.log(date_start);
+          console.log(date_end);
+
+          const arranged = groupExpensesByDay(rows);
+          res.status(200).json({
+            data: {
+              arranged,
+              date_start: date_start,
+              date_end: date_end,
+            },
+          });
+        } else {
+          const { rows } = await pool.query(
+            `SELECT e.total, e.date, ws.date_start, ws.date_end FROM "Expense" e
+            LEFT JOIN
+            "Saved Categories" sc
+            ON e.saved_category_id = sc.saved_category_id
+              JOIN
+              "Weekly Summary" ws
+                ON sc.weekly_summary_id = ws.weekly_summary_id
               ON
                 e.saved_category_id = sc.saved_category_id
               WHERE
                 sc.weekly_summary_id = $1
-            `,
-          [weekly_summary_id]
-        );
+                `,
+            [weekly_summary_id]
+          );
 
-        console.log(rows);
+          console.log(rows);
+          console.log(rows[0].date_start);
+          console.log(rows[0].date_end);
 
-        const arranged = groupExpensesByDay(rows);
-        res.status(200).json({
-          data: {
-            arranged,
-            date_start: rows[0].date_start,
-            date_end: rows[0].date_end,
-          },
-        });
+          const arranged = groupExpensesByDay(rows);
+          res.status(200).json({
+            data: {
+              arranged,
+              date_start: rows[0].date_start,
+              date_end: rows[0].date_end,
+            },
+          });
+        }
       }
     } catch (error) {
       console.error("Error fetching weekly expenses:", error);

--- a/server/routes/expenses.ts
+++ b/server/routes/expenses.ts
@@ -99,27 +99,17 @@ expenseRouter.get(
   async (req: Request, res: Response) => {
     try {
       const { id } = req.params;
-      const currentWeekStart = new Date();
-      currentWeekStart.setDate(
-        currentWeekStart.getDate() - currentWeekStart.getDay()
-      );
-      currentWeekStart.setHours(0, 0, 0, 0);
-
-      const currentWeekEnd = new Date(currentWeekStart);
-      currentWeekEnd.setDate(currentWeekStart.getDate() + 6);
-      currentWeekEnd.setHours(23, 59, 59, 999);
 
       const result = await pool.query(
         `SELECT * FROM "Expense"
           INNER JOIN "Category"
             ON "Expense".category_id = "Category".category_id
           WHERE
-            date BETWEEN $1 AND $2 AND
-            "Category".user_id = $3
+            "Category".user_id = $1
           ORDER BY total DESC
           LIMIT 5
         `,
-        [currentWeekStart.toISOString(), currentWeekEnd.toISOString(), id]
+        [id]
       );
 
       if (result.rows.length > 0) {
@@ -127,7 +117,7 @@ expenseRouter.get(
           data: result.rows,
         });
       } else {
-        res.status(404).json({
+        res.status(200).json({
           message: "No expenses found for the current week.",
         });
       }


### PR DESCRIPTION
What changes have been made? Create brief description on what you added and/or removed:
- added logic on adding the chart on the wrap up info page based on thhe previous weekly summary data 

Anything you are worried about:
- fetching on all bar charts (dashboard, summary page, wrap up info page) may be affected

Picture of the changes you added:
![image](https://github.com/user-attachments/assets/aeccadff-3f29-467c-a0a3-6d487f204665)
![image](https://github.com/user-attachments/assets/0dafb542-4ff2-448d-a13e-a10fc3507ea0)
![image](https://github.com/user-attachments/assets/8309a3a6-401c-4e27-a644-ad4e96ea379f)
![image](https://github.com/user-attachments/assets/22c539d3-85a6-4b9a-9452-0edeec56e04b)
![image](https://github.com/user-attachments/assets/27cb9712-a781-47ff-86a0-6d6e8d427bc0)
![image](https://github.com/user-attachments/assets/ae92b7d2-47dd-40de-b683-2730bbb9f479)
![image](https://github.com/user-attachments/assets/74db1b3a-4262-4dcf-839a-b223c1d483f6)


Picture of the changes you removed:

Any bugs to watch out for:
NA

Please check the box(es) that apply:

- [x]  tested backend + frontend
- [ ]  tested backend only
- [ ]  tested frontend only